### PR TITLE
Make operation more closely reflect README/spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,4 @@ ENV CONF_SSH /etc/ssh
 
 EXPOSE 22
 
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/usr/sbin/sshd", "-D", "-e"]
+ENTRYPOINT ["/entrypoint.sh", "/usr/sbin/sshd", "-D", "-e"]

--- a/sshd_config
+++ b/sshd_config
@@ -12,7 +12,7 @@ AllowTcpForwarding no
 AuthorizedKeysFile %h/.ssh/authorized_keys
 Banner /etc/banner
 ChallengeResponseAuthentication no
-ChrootDirectory /chroot
+ChrootDirectory /data/sftp/chroot
 ClientAliveInterval 300
 ForceCommand internal-sftp -d %u
 HostKey /etc/ssh/ssh_host_rsa_key
@@ -26,6 +26,6 @@ Protocol 2
 StrictModes yes
 Subsystem sftp internal-sftp
 TCPKeepAlive yes
-UsePAM no
+UsePAM yes
 UsePrivilegeSeparation yes
 X11Forwarding no


### PR DESCRIPTION
A few quick changes to make the behaviour match the spec outlined in the README. Also primes a .ssh directory for users to add authorized keys.
